### PR TITLE
Fixes #22

### DIFF
--- a/analyticConfigurations/metric_meta-elastic.search.json
+++ b/analyticConfigurations/metric_meta-elastic.search.json
@@ -91,7 +91,7 @@
         "tags" : {
           "unit" : "percent"
         },
-        "validMax" : 100
+        "validMax" : null
       }
     }, {
       "match" : "elasticsearch\\..*(size|size_in_bytes)$",


### PR DESCRIPTION
Setting elasticsearch.process.cpu.percent validMax to null because it is not normalized and thus can be higher than 100