### PR TITLE
Convert computed metrics to new format

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ### Version next
 
+* Convert computed metrics to new format
 * Adjusted build to use metricly-cli for validation
 
 ### Version 1.8.0

--- a/analyticConfigurations/computed_metric-elastic.search.json
+++ b/analyticConfigurations/computed_metric-elastic.search.json
@@ -4,239 +4,300 @@
       {
         "match": "netuitive.linux.elasticsearch.cpu.normalizedpercent",
         "properties": {
-          "expression": "attribute['cpus'] == null ? null : (data['elasticsearch.process.cpu.percent'].actual / attribute['cpus'].value)",
+          "expressions": [
+            "${elasticsearch.process.cpu.percent}.actual / attribute(cpus)",
+            "0"
+          ],
           "fqn": "netuitive.linux.elasticsearch.cpu.normalizedpercent"
         }
       },
       {
         "match": "elasticsearch.indices.index.flush.avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.flush.total_time_in_millis'].actual / data['elasticsearch.indices.${1}.flush.total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.flush\\.total_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.flush.total_time_in_millis}.actual / ${elasticsearch.indices.${1}.flush.total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.flush\\.total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.flush.avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.get.exists_avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.get.exists_time_in_millis'].actual / data['elasticsearch.indices.${1}.get.exists_total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.get\\.exists_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.get.exists_time_in_millis}.actual / ${elasticsearch.indices.${1}.get.exists_total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.get\\.exists_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.exists_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.get.missing_avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.get.missing_time_in_millis'].actual / data['elasticsearch.indices.${1}.get.missing_total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.get\\.missing_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.get.missing_time_in_millis}.actual / ${elasticsearch.indices.${1}.get.missing_total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.get\\.missing_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.missing_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.get.avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.get.time_in_millis'].actual / data['elasticsearch.indices.${1}.get.total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.get\\.time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.get.time_in_millis}.actual / ${elasticsearch.indices.${1}.get.total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.get\\.time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.indexing.delete_avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.indexing.delete_time_in_millis'].actual / data['elasticsearch.indices.${1}.indexing.delete_total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.delete_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.indexing.delete_time_in_millis}.actual / ${elasticsearch.indices.${1}.indexing.delete_total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.delete_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.delete_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.indexing.index_avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.indexing.index_time_in_millis'].actual / data['elasticsearch.indices.${1}.indexing.index_total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.index_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.indexing.index_time_in_millis}.actual / ${elasticsearch.indices.${1}.indexing.index_total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.index_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.index_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.merges.avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.merges.total_time_in_millis'].actual / data['elasticsearch.indices.${1}.merges.total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.merges\\.total_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.merges.total_time_in_millis}.actual / ${elasticsearch.indices.${1}.merges.total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.merges\\.total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.merges.avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.refresh.avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.refresh.total_time_in_millis'].actual / data['elasticsearch.indices.${1}.refresh.total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.refresh\\.total_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.refresh.total_time_in_millis}.actual / ${elasticsearch.indices.${1}.refresh.total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.refresh\\.total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.refresh.avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.fetch_avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.search.fetch_time_in_millis'].actual / data['elasticsearch.indices.${1}.search.fetch_total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.search\\.fetch_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.search.fetch_time_in_millis}.actual / ${elasticsearch.indices.${1}.search.fetch_total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.fetch_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.fetch_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.query_avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.search.query_time_in_millis'].actual / data['elasticsearch.indices.${1}.search.query_total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.search\\.query_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.search.query_time_in_millis}.actual / ${elasticsearch.indices.${1}.search.query_total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.query_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.query_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.scroll_avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.search.scroll_time_in_millis'].actual / data['elasticsearch.indices.${1}.search.scroll_total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.search\\.scroll_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.search.scroll_time_in_millis}.actual / ${elasticsearch.indices.${1}.search.scroll_total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.scroll_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.scroll_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.suggest_avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.search.suggest_time_in_millis'].actual / data['elasticsearch.indices.${1}.search.suggest_total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.search\\.suggest_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.search.suggest_time_in_millis}.actual / ${elasticsearch.indices.${1}.search.suggest_total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.suggest_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.suggest_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.warmer.avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.warmer.total_time_in_millis'].actual / data['elasticsearch.indices.${1}.warmer.total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.warmer\\.total_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.warmer.total_time_in_millis}.actual / ${elasticsearch.indices.${1}.warmer.total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.warmer\\.total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.warmer.avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.percolate.avg_time_in_millis",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.percolate.time_in_millis'].actual / data['elasticsearch.indices.${1}.percolate.total'].actual",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.percolate\\.total_time_in_millis",
+          "expressions": [
+            "${elasticsearch.indices.${1}.percolate.time_in_millis}.actual / ${elasticsearch.indices.${1}.percolate.total}.actual"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.percolate\\.total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.percolate.avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.flush.total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.flush.total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.flush\\.total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.flush.total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.flush\\.total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.flush.avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.get.exists_total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.get.exists_total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.get\\.exists_total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.get.exists_total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.get\\.exists_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.exists_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.get.missing_total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.get.missing_total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.get\\.missing_total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.get.missing_total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.get\\.missing_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.missing_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.get.total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.get.total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.get\\.total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.get.total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.get\\.total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.indexing.delete_total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.indexing.delete_total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.delete_total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.indexing.delete_total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.delete_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.delete_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.indexing.index_total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.indexing.index_total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.index_total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.indexing.index_total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.index_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.index_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.indexing.noop_update_total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.indexing.noop_update_total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.noop_update_total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.indexing.noop_update_total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.noop_update_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.noop_update_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.merges.total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.merges.total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.merges\\.total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.merges.total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.merges\\.total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.merges.avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.percolate.total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.percolate.total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.percolate\\.total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.percolate.total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.percolate\\.total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.percolate.avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.refresh.total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.refresh.total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.refresh\\.total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.refresh.total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.refresh\\.total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.refresh.avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.fetch_total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.search.fetch_total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.search\\.fetch_total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.search.fetch_total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.fetch_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.fetch_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.query_total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.search.query_total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.search\\.query_total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.search.query_total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.query_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.query_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.scroll_total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.search.scroll_total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.search\\.scroll_total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.search.scroll_total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.scroll_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.scroll_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.suggest.total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.suggest.total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.suggest\\.total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.suggest.total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.suggest\\.total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.suggest.avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.warmer.total",
         "properties": {
-          "expression": "data['elasticsearch.indices.${1}.warmer.total'].actual / 300",
-          "for": "elasticsearch\\.indices\\.(.*?)\\.warmer\\.total",
+          "expressions": [
+            "${elasticsearch.indices.${1}.warmer.total}.actual / 300"
+          ],
+          "capture": "elasticsearch\\.indices\\.(.*?)\\.warmer\\.total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.warmer.avg_per_sec"
         }
       }

--- a/analyticConfigurations/computed_metric-elastic.search.json
+++ b/analyticConfigurations/computed_metric-elastic.search.json
@@ -14,290 +14,290 @@
       {
         "match": "elasticsearch.indices.index.flush.avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]flush[.]total_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.flush.total_time_in_millis}.actual / ${elasticsearch.indices.${1}.flush.total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]flush[.]total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.flush.avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.get.exists_avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]exists_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.get.exists_time_in_millis}.actual / ${elasticsearch.indices.${1}.get.exists_total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]exists_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.exists_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.get.missing_avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]missing_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.get.missing_time_in_millis}.actual / ${elasticsearch.indices.${1}.get.missing_total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]missing_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.missing_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.get.avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.get.time_in_millis}.actual / ${elasticsearch.indices.${1}.get.total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.indexing.delete_avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]delete_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.indexing.delete_time_in_millis}.actual / ${elasticsearch.indices.${1}.indexing.delete_total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]delete_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.delete_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.indexing.index_avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]index_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.indexing.index_time_in_millis}.actual / ${elasticsearch.indices.${1}.indexing.index_total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]index_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.index_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.merges.avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]merges[.]total_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.merges.total_time_in_millis}.actual / ${elasticsearch.indices.${1}.merges.total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]merges[.]total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.merges.avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.refresh.avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]refresh[.]total_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.refresh.total_time_in_millis}.actual / ${elasticsearch.indices.${1}.refresh.total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]refresh[.]total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.refresh.avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.fetch_avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]fetch_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.search.fetch_time_in_millis}.actual / ${elasticsearch.indices.${1}.search.fetch_total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]fetch_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.fetch_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.query_avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]query_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.search.query_time_in_millis}.actual / ${elasticsearch.indices.${1}.search.query_total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]query_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.query_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.scroll_avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]scroll_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.search.scroll_time_in_millis}.actual / ${elasticsearch.indices.${1}.search.scroll_total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]scroll_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.scroll_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.suggest_avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]suggest_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.search.suggest_time_in_millis}.actual / ${elasticsearch.indices.${1}.search.suggest_total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]suggest_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.suggest_avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.warmer.avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]warmer[.]total_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.warmer.total_time_in_millis}.actual / ${elasticsearch.indices.${1}.warmer.total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]warmer[.]total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.warmer.avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.percolate.avg_time_in_millis",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]percolate[.]total_time_in_millis",
           "expressions": [
             "${elasticsearch.indices.${1}.percolate.time_in_millis}.actual / ${elasticsearch.indices.${1}.percolate.total}.actual"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]percolate[.]total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.percolate.avg_time_in_millis"
         }
       },
       {
         "match": "elasticsearch.indices.index.flush.total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]flush[.]total",
           "expressions": [
             "${elasticsearch.indices.${1}.flush.total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]flush[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.flush.avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.get.exists_total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]exists_total",
           "expressions": [
             "${elasticsearch.indices.${1}.get.exists_total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]exists_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.exists_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.get.missing_total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]missing_total",
           "expressions": [
             "${elasticsearch.indices.${1}.get.missing_total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]missing_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.missing_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.get.total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]total",
           "expressions": [
             "${elasticsearch.indices.${1}.get.total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.indexing.delete_total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]delete_total",
           "expressions": [
             "${elasticsearch.indices.${1}.indexing.delete_total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]delete_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.delete_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.indexing.index_total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]index_total",
           "expressions": [
             "${elasticsearch.indices.${1}.indexing.index_total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]index_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.index_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.indexing.noop_update_total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]noop_update_total",
           "expressions": [
             "${elasticsearch.indices.${1}.indexing.noop_update_total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]noop_update_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.noop_update_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.merges.total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]merges[.]total",
           "expressions": [
             "${elasticsearch.indices.${1}.merges.total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]merges[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.merges.avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.percolate.total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]percolate[.]total",
           "expressions": [
             "${elasticsearch.indices.${1}.percolate.total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]percolate[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.percolate.avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.refresh.total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]refresh[.]total",
           "expressions": [
             "${elasticsearch.indices.${1}.refresh.total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]refresh[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.refresh.avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.fetch_total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]fetch_total",
           "expressions": [
             "${elasticsearch.indices.${1}.search.fetch_total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]fetch_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.fetch_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.query_total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]query_total",
           "expressions": [
             "${elasticsearch.indices.${1}.search.query_total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]query_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.query_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.search.scroll_total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]scroll_total",
           "expressions": [
             "${elasticsearch.indices.${1}.search.scroll_total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]scroll_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.scroll_avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.suggest.total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]suggest[.]total",
           "expressions": [
             "${elasticsearch.indices.${1}.suggest.total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]suggest[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.suggest.avg_per_sec"
         }
       },
       {
         "match": "elasticsearch.indices.index.warmer.total",
         "properties": {
+          "capture": "elasticsearch[.]indices[.](.*?)[.]warmer[.]total",
           "expressions": [
             "${elasticsearch.indices.${1}.warmer.total}.actual / 300"
           ],
-          "capture": "elasticsearch[.]indices[.](.*?)[.]warmer[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.warmer.avg_per_sec"
         }
       }

--- a/analyticConfigurations/computed_metric-elastic.search.json
+++ b/analyticConfigurations/computed_metric-elastic.search.json
@@ -17,7 +17,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.flush.total_time_in_millis}.actual / ${elasticsearch.indices.${1}.flush.total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.flush\\.total_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]flush[.]total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.flush.avg_time_in_millis"
         }
       },
@@ -27,7 +27,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.get.exists_time_in_millis}.actual / ${elasticsearch.indices.${1}.get.exists_total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.get\\.exists_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]exists_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.exists_avg_time_in_millis"
         }
       },
@@ -37,7 +37,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.get.missing_time_in_millis}.actual / ${elasticsearch.indices.${1}.get.missing_total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.get\\.missing_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]missing_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.missing_avg_time_in_millis"
         }
       },
@@ -47,7 +47,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.get.time_in_millis}.actual / ${elasticsearch.indices.${1}.get.total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.get\\.time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.avg_time_in_millis"
         }
       },
@@ -57,7 +57,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.indexing.delete_time_in_millis}.actual / ${elasticsearch.indices.${1}.indexing.delete_total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.delete_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]delete_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.delete_avg_time_in_millis"
         }
       },
@@ -67,7 +67,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.indexing.index_time_in_millis}.actual / ${elasticsearch.indices.${1}.indexing.index_total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.index_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]index_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.index_avg_time_in_millis"
         }
       },
@@ -77,7 +77,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.merges.total_time_in_millis}.actual / ${elasticsearch.indices.${1}.merges.total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.merges\\.total_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]merges[.]total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.merges.avg_time_in_millis"
         }
       },
@@ -87,7 +87,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.refresh.total_time_in_millis}.actual / ${elasticsearch.indices.${1}.refresh.total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.refresh\\.total_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]refresh[.]total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.refresh.avg_time_in_millis"
         }
       },
@@ -97,7 +97,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.search.fetch_time_in_millis}.actual / ${elasticsearch.indices.${1}.search.fetch_total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.fetch_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]fetch_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.fetch_avg_time_in_millis"
         }
       },
@@ -107,7 +107,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.search.query_time_in_millis}.actual / ${elasticsearch.indices.${1}.search.query_total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.query_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]query_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.query_avg_time_in_millis"
         }
       },
@@ -117,7 +117,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.search.scroll_time_in_millis}.actual / ${elasticsearch.indices.${1}.search.scroll_total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.scroll_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]scroll_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.scroll_avg_time_in_millis"
         }
       },
@@ -127,7 +127,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.search.suggest_time_in_millis}.actual / ${elasticsearch.indices.${1}.search.suggest_total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.suggest_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]suggest_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.suggest_avg_time_in_millis"
         }
       },
@@ -137,7 +137,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.warmer.total_time_in_millis}.actual / ${elasticsearch.indices.${1}.warmer.total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.warmer\\.total_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]warmer[.]total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.warmer.avg_time_in_millis"
         }
       },
@@ -147,7 +147,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.percolate.time_in_millis}.actual / ${elasticsearch.indices.${1}.percolate.total}.actual"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.percolate\\.total_time_in_millis",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]percolate[.]total_time_in_millis",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.percolate.avg_time_in_millis"
         }
       },
@@ -157,7 +157,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.flush.total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.flush\\.total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]flush[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.flush.avg_per_sec"
         }
       },
@@ -167,7 +167,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.get.exists_total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.get\\.exists_total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]exists_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.exists_avg_per_sec"
         }
       },
@@ -177,7 +177,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.get.missing_total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.get\\.missing_total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]missing_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.missing_avg_per_sec"
         }
       },
@@ -187,7 +187,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.get.total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.get\\.total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]get[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.get.avg_per_sec"
         }
       },
@@ -197,7 +197,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.indexing.delete_total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.delete_total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]delete_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.delete_avg_per_sec"
         }
       },
@@ -207,7 +207,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.indexing.index_total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.index_total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]index_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.index_avg_per_sec"
         }
       },
@@ -217,7 +217,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.indexing.noop_update_total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.indexing\\.noop_update_total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]indexing[.]noop_update_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.indexing.noop_update_avg_per_sec"
         }
       },
@@ -227,7 +227,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.merges.total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.merges\\.total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]merges[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.merges.avg_per_sec"
         }
       },
@@ -237,7 +237,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.percolate.total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.percolate\\.total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]percolate[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.percolate.avg_per_sec"
         }
       },
@@ -247,7 +247,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.refresh.total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.refresh\\.total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]refresh[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.refresh.avg_per_sec"
         }
       },
@@ -257,7 +257,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.search.fetch_total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.fetch_total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]fetch_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.fetch_avg_per_sec"
         }
       },
@@ -267,7 +267,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.search.query_total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.query_total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]query_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.query_avg_per_sec"
         }
       },
@@ -277,7 +277,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.search.scroll_total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.search\\.scroll_total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]search[.]scroll_total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.search.scroll_avg_per_sec"
         }
       },
@@ -287,7 +287,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.suggest.total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.suggest\\.total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]suggest[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.suggest.avg_per_sec"
         }
       },
@@ -297,7 +297,7 @@
           "expressions": [
             "${elasticsearch.indices.${1}.warmer.total}.actual / 300"
           ],
-          "capture": "elasticsearch\\.indices\\.(.*?)\\.warmer\\.total",
+          "capture": "elasticsearch[.]indices[.](.*?)[.]warmer[.]total",
           "fqn": "netuitive.linux.elasticsearch.indices.${1}.warmer.avg_per_sec"
         }
       }
@@ -305,7 +305,7 @@
     "name": "Elastic Search",
     "scope": {
       "elementType": "SERVER",
-      "metricMatches": "^elasticsearch\\..*"
+      "metricMatches": "^elasticsearch[.].*"
     },
     "type": "COMPUTED_METRIC"
   }


### PR DESCRIPTION
The first expression had an attribute change. All other expressions had no functional change other than:
- `expression` string => `expressions` array
- `data['` => `${`
- `']` => `}`
- `for` => `capture`